### PR TITLE
 Schema changes to optimise Steve

### DIFF
--- a/steve-client-scala/src/main/scala/steve/client/SteveClient.scala
+++ b/steve-client-scala/src/main/scala/steve/client/SteveClient.scala
@@ -8,15 +8,19 @@ import scalaj.http.BaseHttp
 case class ClientException(private val message: String = "",
                            private val cause: Throwable = None.orNull)
   extends Exception(message, cause)
+
 case class ItemBatch(items: List[Map[String, Any]]) {
   def +(another: ItemBatch) = ItemBatch(items ++ another.items)
 }
 
 object ItemBatch {
-  def apply(jobId: String, status: String, attributes: Map[String,String]): ItemBatch = {
-    ItemBatch(List(Map[String,Any]("jobId" -> jobId, "status" -> status, "attributes" -> attributes)))
+  def apply(jobId: String, status: String, attributes: Map[String, String]): ItemBatch = {
+    ItemBatch(List(Map[String, Any]("jobId" -> jobId, "status" -> status, "attributes" -> attributes)))
   }
 
+  def apply(id: String, jobId: String, status: String, attributes: Map[String, String]): ItemBatch = {
+    ItemBatch(List(Map[String, Any]("id" -> id, "jobId" -> jobId, "status" -> status, "attributes" -> attributes)))
+  }
 }
 
 //TODO: Handle retries in the client logic
@@ -24,14 +28,14 @@ class SteveClient(httpClient: BaseHttp, host: String) {
   val connectionTimeoutInMillis = 10000
   val readTimeoutInMillis = 30000
 
-  def addJob(appName: String, state: String, attributes: Map[String,String]): Option[String] = {
-    val jsonInput = Map[String,Any]("appName" -> appName, "state" -> state, "attributes" -> attributes)
+  def addJob(appName: String, state: String, attributes: Map[String, String]): Option[String] = {
+    val jsonInput = Map[String, Any]("appName" -> appName, "state" -> state, "attributes" -> attributes)
     val data = JsonUtils.toJson(jsonInput)
     val response = httpClient(s"$host/job")
       .postData(data)
       .header("content-type", "application/json")
       .method("PUT")
-      .timeout(connTimeoutMs = connectionTimeoutInMillis,readTimeoutMs = readTimeoutInMillis)
+      .timeout(connTimeoutMs = connectionTimeoutInMillis, readTimeoutMs = readTimeoutInMillis)
       .asString
     val jobInfo = JsonUtils.fromJson[Map[String, String]](response.body)
     jobInfo.get("id")
@@ -40,7 +44,7 @@ class SteveClient(httpClient: BaseHttp, host: String) {
   def getJob(jobId: String): Job = {
     val response = httpClient(s"$host/job/$jobId")
       .method("GET")
-      .timeout(connTimeoutMs = connectionTimeoutInMillis,readTimeoutMs = readTimeoutInMillis)
+      .timeout(connTimeoutMs = connectionTimeoutInMillis, readTimeoutMs = readTimeoutInMillis)
       .asString
     val jobInfo = JsonUtils.fromJson[Job](response.body)
     jobInfo
@@ -49,7 +53,7 @@ class SteveClient(httpClient: BaseHttp, host: String) {
   def getJobIdsByState(state: String) = {
     val response = httpClient(s"$host/job?state=$state")
       .method("GET")
-      .timeout(connTimeoutMs = connectionTimeoutInMillis,readTimeoutMs = readTimeoutInMillis)
+      .timeout(connTimeoutMs = connectionTimeoutInMillis, readTimeoutMs = readTimeoutInMillis)
       .asString
     JsonUtils.fromJson[List[String]](response.body)
   }
@@ -59,7 +63,7 @@ class SteveClient(httpClient: BaseHttp, host: String) {
       .postData(state)
       .header("content-type", "application/json")
       .method("POST")
-      .timeout(connTimeoutMs = connectionTimeoutInMillis,readTimeoutMs = readTimeoutInMillis)
+      .timeout(connTimeoutMs = connectionTimeoutInMillis, readTimeoutMs = readTimeoutInMillis)
       .asString
     response.is2xx
   }
@@ -67,7 +71,7 @@ class SteveClient(httpClient: BaseHttp, host: String) {
   def deleteJob(jobId: String): Option[String] = {
     val response = httpClient(s"$host/job/$jobId")
       .method("DELETE")
-      .timeout(connTimeoutMs = connectionTimeoutInMillis,readTimeoutMs = readTimeoutInMillis)
+      .timeout(connTimeoutMs = connectionTimeoutInMillis, readTimeoutMs = readTimeoutInMillis)
       .asString
     val jobInfo = JsonUtils.fromJson[Map[String, String]](response.body)
     jobInfo.get("rowsAffected")
@@ -76,20 +80,20 @@ class SteveClient(httpClient: BaseHttp, host: String) {
   def getJobStats(jobId: String): Map[String, Int] = {
     val response = httpClient(s"$host/job/$jobId/stats")
       .method("GET")
-      .timeout(connTimeoutMs = connectionTimeoutInMillis,readTimeoutMs = readTimeoutInMillis)
+      .timeout(connTimeoutMs = connectionTimeoutInMillis, readTimeoutMs = readTimeoutInMillis)
       .asString
     val jobStats = JsonUtils.fromJson[Map[String, Int]](response.body)
     jobStats
   }
 
-  def addItem(jobId: String, status: String, attributes: Map[String,String]): Option[String] = {
-    val jsonInput = Map[String,Any]("jobId" -> jobId, "status" -> status, "attributes" -> attributes)
+  def addItem(jobId: String, status: String, attributes: Map[String, String]): Option[String] = {
+    val jsonInput = Map[String, Any]("jobId" -> jobId, "status" -> status, "attributes" -> attributes)
     val data = JsonUtils.toJson(jsonInput)
     val response = httpClient(s"$host/item")
       .postData(data)
       .header("content-type", "application/json")
       .method("PUT")
-      .timeout(connTimeoutMs = connectionTimeoutInMillis,readTimeoutMs = readTimeoutInMillis)
+      .timeout(connTimeoutMs = connectionTimeoutInMillis, readTimeoutMs = readTimeoutInMillis)
       .asString
     val itemInfo = JsonUtils.fromJson[Map[String, String]](response.body)
     itemInfo.get("id")
@@ -101,7 +105,7 @@ class SteveClient(httpClient: BaseHttp, host: String) {
       .postData(data)
       .header("content-type", "application/json")
       .method("PUT")
-      .timeout(connTimeoutMs = connectionTimeoutInMillis,readTimeoutMs = readTimeoutInMillis)
+      .timeout(connTimeoutMs = connectionTimeoutInMillis, readTimeoutMs = readTimeoutInMillis)
       .asString
     response.is2xx
   }
@@ -109,7 +113,7 @@ class SteveClient(httpClient: BaseHttp, host: String) {
   def getItem(itemId: String): Item = {
     val response = httpClient(s"$host/item/$itemId")
       .method("GET")
-      .timeout(connTimeoutMs = connectionTimeoutInMillis,readTimeoutMs = readTimeoutInMillis)
+      .timeout(connTimeoutMs = connectionTimeoutInMillis, readTimeoutMs = readTimeoutInMillis)
       .asString
     val itemInfo = JsonUtils.fromJson[Item](response.body)
     itemInfo
@@ -118,11 +122,11 @@ class SteveClient(httpClient: BaseHttp, host: String) {
   private def checkItemByStatus(qpString: String) = {
     val response = httpClient(s"$host/item/status?$qpString")
       .method("HEAD")
-      .timeout(connTimeoutMs = connectionTimeoutInMillis,readTimeoutMs = readTimeoutInMillis)
+      .timeout(connTimeoutMs = connectionTimeoutInMillis, readTimeoutMs = readTimeoutInMillis)
       .asString
-    if(response.is2xx)
+    if (response.is2xx)
       true
-    else if(response.is4xx)
+    else if (response.is4xx)
       false
     else
       throw ClientException(response.toString)
@@ -142,21 +146,21 @@ class SteveClient(httpClient: BaseHttp, host: String) {
       .postData(status)
       .header("content-type", "application/json")
       .method("POST")
-      .timeout(connTimeoutMs = connectionTimeoutInMillis,readTimeoutMs = readTimeoutInMillis)
+      .timeout(connTimeoutMs = connectionTimeoutInMillis, readTimeoutMs = readTimeoutInMillis)
       .asString
     response.is2xx
   }
 
-  def updateItemStatus(queryAttrs: Map[String, String], queryStatus: Option[String], updateStatus:String): Boolean = {
+  def updateItemStatus(queryAttrs: Map[String, String], queryStatus: Option[String], updateStatus: String): Boolean = {
     val qsMap = queryStatus.map(status => Map("status" -> status)).getOrElse(Map()) ++ queryAttrs
-    val queryString = qsMap.map{
-      case(key,value) => key + "=" + value
+    val queryString = qsMap.map {
+      case (key, value) => key + "=" + value
     }.mkString("&")
     val response = httpClient(s"$host/item/status?$queryString")
       .postData(updateStatus)
       .header("content-type", "application/json")
       .method("POST")
-      .timeout(connTimeoutMs = connectionTimeoutInMillis,readTimeoutMs = readTimeoutInMillis)
+      .timeout(connTimeoutMs = connectionTimeoutInMillis, readTimeoutMs = readTimeoutInMillis)
       .asString
     response.is2xx
   }
@@ -164,7 +168,7 @@ class SteveClient(httpClient: BaseHttp, host: String) {
   def deleteItem(itemId: String): Option[String] = {
     val response = httpClient(s"$host/item/$itemId")
       .method("DELETE")
-      .timeout(connTimeoutMs = connectionTimeoutInMillis,readTimeoutMs = readTimeoutInMillis)
+      .timeout(connTimeoutMs = connectionTimeoutInMillis, readTimeoutMs = readTimeoutInMillis)
       .asString
     val itemInfo = JsonUtils.fromJson[Map[String, String]](response.body)
     itemInfo.get("rowsAffected")

--- a/steve-client-scala/src/test/scala/steve/client/SteveClientSpec.scala
+++ b/steve-client-scala/src/test/scala/steve/client/SteveClientSpec.scala
@@ -34,7 +34,7 @@ class SteveClientSpec extends FlatSpec {
   }
 
   it should "get the Job's details for a given Job ID" in {
-    val jobId = UUID.randomUUID
+    val jobId = 1L
     val dummyJob = Job(id = jobId, appName = "cannonball", state = "START", createdAt = new Date(), updatedAt = None, attributes = Map("test" -> "test"))
     val dummyResponse = JsonUtils.toJson(dummyJob)
 
@@ -130,8 +130,8 @@ class SteveClientSpec extends FlatSpec {
   }
 
   it should "get the Item's details for a given Item ID" in {
-    val itemId = UUID.randomUUID
-    val jobId = UUID.randomUUID
+    val itemId = UUID.randomUUID.toString
+    val jobId = 1L
     val dummyItem = Item(id = itemId, jobId = jobId, status = "START", createdAt = new Date(), updatedAt = None, attributes = Map("test" -> "test"))
     val dummyResponse = JsonUtils.toJson(dummyItem)
 

--- a/steve-core/src/main/scala/domain/Item.scala
+++ b/steve-core/src/main/scala/domain/Item.scala
@@ -1,9 +1,9 @@
 package domain
 
-import java.util.{Date, UUID}
+import java.util.Date
 
-case class Item(id: UUID,
-                jobId: UUID,
+case class Item(id: String,
+                jobId: Long,
                 status: String,
                 createdAt: Date,
                 updatedAt: Option[Date],

--- a/steve-core/src/main/scala/domain/Job.scala
+++ b/steve-core/src/main/scala/domain/Job.scala
@@ -1,8 +1,8 @@
 package domain
 
-import java.util.{Date, UUID}
+import java.util.Date
 
-case class Job(id: UUID,
+case class Job(id: Long,
                appName: String,
                state: String,
                createdAt: Date,

--- a/steve-server/src/main/resources/db/migration/V1__Create_job_and_item_tables.sql
+++ b/steve-server/src/main/resources/db/migration/V1__Create_job_and_item_tables.sql
@@ -1,5 +1,5 @@
-create table if not exists "job" (
-  "id" UUID PRIMARY KEY,
+CREATE TABLE IF NOT EXISTS "job" (
+  "id" BIGSERIAL PRIMARY KEY,
   "app_name" TEXT NOT NULL,
   "state" TEXT NOT NULL,
   "attributes" HSTORE NULL DEFAULT NULL,
@@ -7,11 +7,13 @@ create table if not exists "job" (
   updated_at TIMESTAMP WITHOUT TIME ZONE NULL DEFAULT NULL
 );
 
-create table if not exists "item" (
-  "id" UUID PRIMARY KEY,
-  "job_id" UUID NOT NULL REFERENCES job(id) ON DELETE CASCADE,
+
+CREATE TABLE IF NOT EXISTS "item" (
+  "id" TEXT NOT NULL,
+  "job_id" BIGINT NOT NULL REFERENCES job(id) ON DELETE CASCADE,
   "status" TEXT NOT NULL,
   "attributes" HSTORE NULL DEFAULT NULL,
   created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT now(),
-  updated_at TIMESTAMP WITHOUT TIME ZONE NULL DEFAULT NULL
+  updated_at TIMESTAMP WITHOUT TIME ZONE NULL DEFAULT NULL,
+  PRIMARY KEY("id", "job_id")
 );

--- a/steve-server/src/main/scala/controller/ItemController.scala
+++ b/steve-server/src/main/scala/controller/ItemController.scala
@@ -12,9 +12,9 @@ import domain.Item
 import steve.SteveConfiguration
 import utils.DateConverter._
 
+import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}
-import scala.collection.JavaConverters._
 
 @Path("/item")
 class ItemController @Inject()(steveConfiguration: SteveConfiguration, items: Items, implicit val ec: ExecutionContext) {
@@ -23,11 +23,12 @@ class ItemController @Inject()(steveConfiguration: SteveConfiguration, items: It
   @Path("/")
   @Produces(Array(MediaType.APPLICATION_JSON))
   def createItem(item: Item, @Suspended res: AsyncResponse) = {
-    val newItem: Item = item.copy(id = UUID.randomUUID, createdAt = new Date())
+    val newItem: Item = item.copy(id = Option(item.id).getOrElse(UUID.randomUUID.toString), createdAt = new Date())
     items.insert(newItem).onComplete {
       case Success(_) => res.resume(Response.status(Status.CREATED).entity(Map("id" -> newItem.id, "msg" -> "Created")).build())
       case Failure(error) => {
-        error.printStackTrace(); res.resume(Response.status(Status.INTERNAL_SERVER_ERROR).entity(Map("msg" -> error.getMessage)).build())
+        error.printStackTrace();
+        res.resume(Response.status(Status.INTERNAL_SERVER_ERROR).entity(Map("msg" -> error.getMessage)).build())
       }
     }
   }
@@ -36,11 +37,14 @@ class ItemController @Inject()(steveConfiguration: SteveConfiguration, items: It
   @Path("/bulk")
   @Produces(Array(MediaType.APPLICATION_JSON))
   def createItems(itemList: List[Item], @Suspended res: AsyncResponse) = {
-    val newItems = itemList.map(item => item.copy(id = UUID.randomUUID, createdAt = new Date()))
+    println(itemList)
+
+    val newItems = itemList.map(item => item.copy(id = Option(item.id).getOrElse(UUID.randomUUID.toString), createdAt = new Date()))
     items.insert(newItems).onComplete {
       case Success(_) => res.resume(Response.status(Status.CREATED).entity(Map("msg" -> "Created")).build())
       case Failure(error) => {
-        error.printStackTrace(); res.resume(Response.status(Status.INTERNAL_SERVER_ERROR).entity(Map("msg" -> error.getMessage)).build())
+        error.printStackTrace();
+        res.resume(Response.status(Status.INTERNAL_SERVER_ERROR).entity(Map("msg" -> error.getMessage)).build())
       }
     }
   }
@@ -48,7 +52,7 @@ class ItemController @Inject()(steveConfiguration: SteveConfiguration, items: It
   @GET
   @Path("/{id}")
   @Produces(Array(MediaType.APPLICATION_JSON))
-  def getItem(@PathParam("id") itemId: UUID, @Suspended res: AsyncResponse) = {
+  def getItem(@PathParam("id") itemId: String, @Suspended res: AsyncResponse) = {
     items.select(itemId).onComplete {
       case Success(Some(item)) => res.resume(Response.status(Status.OK).entity(item).build())
       case Success(None) => res.resume(Response.status(Status.NOT_FOUND).entity(Map("id" -> itemId, "msg" -> "Not Found")).build())
@@ -60,7 +64,7 @@ class ItemController @Inject()(steveConfiguration: SteveConfiguration, items: It
   @HEAD
   @Path("/status")
   @Produces(Array(MediaType.APPLICATION_JSON))
-  def checkItemStatus(@QueryParam("jobId") jobId: UUID, @QueryParam("status") status: String, @Suspended res: AsyncResponse) = {
+  def checkItemStatus(@QueryParam("jobId") jobId: Long, @QueryParam("status") status: String, @Suspended res: AsyncResponse) = {
     if (status.startsWith("!")) {
       if (status.size < 2)
         res.resume(Response.status(Status.BAD_REQUEST).entity(Map("msg" -> "Invalid query param: status")).build())
@@ -83,7 +87,7 @@ class ItemController @Inject()(steveConfiguration: SteveConfiguration, items: It
   @POST
   @Path("/{id}")
   @Produces(Array(MediaType.APPLICATION_JSON))
-  def updateItem(@PathParam("id") itemId: UUID, item: Item, @Suspended res: AsyncResponse) = {
+  def updateItem(@PathParam("id") itemId: String, item: Item, @Suspended res: AsyncResponse) = {
     val updatedItem: Item = item.copy(id = itemId, updatedAt = Some(new Date()))
     items.update(updatedItem).onComplete {
       case Success(_) => res.resume(Response.status(Status.OK).entity(updatedItem).build())
@@ -94,7 +98,7 @@ class ItemController @Inject()(steveConfiguration: SteveConfiguration, items: It
   @POST
   @Path("/{id}/status")
   @Produces(Array(MediaType.APPLICATION_JSON))
-  def updateItemStatusById(@PathParam("id") itemId: UUID, status: String, @Suspended res: AsyncResponse) = {
+  def updateItemStatusById(@PathParam("id") itemId: String, status: String, @Suspended res: AsyncResponse) = {
     val id = Option(itemId)
     items.updateStatus(id, None, None, Map(), status).onComplete {
       case Success(_) => res.resume(Response.status(Status.OK).entity(Map("msg" -> "Updated")).build())
@@ -106,8 +110,8 @@ class ItemController @Inject()(steveConfiguration: SteveConfiguration, items: It
   @Path("/status")
   @Produces(Array(MediaType.APPLICATION_JSON))
   def updateItemStatus(@Context info: UriInfo, status: String, @Suspended res: AsyncResponse) = {
-    val id = Option(info.getQueryParameters.getFirst("id")).map(id => UUID.fromString(id))
-    val jobId = Option(info.getQueryParameters.getFirst("jobId")).map(id => UUID.fromString(id))
+    val id = Option(info.getQueryParameters.getFirst("id"))
+    val jobId = Option(info.getQueryParameters.getFirst("jobId").toLong)
     val queryStatus = Option(info.getQueryParameters.getFirst("status"))
     //Taking only the first value in the list of values if passed, for the attributes
     //TODO: May be throw bad request if the above contract is breached?
@@ -121,7 +125,7 @@ class ItemController @Inject()(steveConfiguration: SteveConfiguration, items: It
   @DELETE
   @Path("/{id}")
   @Produces(Array(MediaType.APPLICATION_JSON))
-  def deleteItem(@PathParam("id") itemId: UUID, @Suspended res: AsyncResponse) = {
+  def deleteItem(@PathParam("id") itemId: String, @Suspended res: AsyncResponse) = {
     items.delete(itemId).onComplete {
       case Success(rowsDeleted) if rowsDeleted == 0 => res.resume(Response.status(Status.NOT_FOUND).entity(Map("id" -> itemId, "msg" -> "Not Found")).build())
       case Success(rowsDeleted) => res.resume(Response.status(Status.OK).entity(Map("id" -> itemId, "msg" -> s"Deleted", "rowsAffected" -> rowsDeleted)).build())

--- a/steve-server/src/main/scala/controller/ItemController.scala
+++ b/steve-server/src/main/scala/controller/ItemController.scala
@@ -26,10 +26,7 @@ class ItemController @Inject()(steveConfiguration: SteveConfiguration, items: It
     val newItem: Item = item.copy(id = Option(item.id).getOrElse(UUID.randomUUID.toString), createdAt = new Date())
     items.insert(newItem).onComplete {
       case Success(_) => res.resume(Response.status(Status.CREATED).entity(Map("id" -> newItem.id, "msg" -> "Created")).build())
-      case Failure(error) => {
-        error.printStackTrace();
-        res.resume(Response.status(Status.INTERNAL_SERVER_ERROR).entity(Map("msg" -> error.getMessage)).build())
-      }
+      case Failure(error) => res.resume(Response.status(Status.INTERNAL_SERVER_ERROR).entity(Map("msg" -> error.getMessage)).build())
     }
   }
 
@@ -37,15 +34,10 @@ class ItemController @Inject()(steveConfiguration: SteveConfiguration, items: It
   @Path("/bulk")
   @Produces(Array(MediaType.APPLICATION_JSON))
   def createItems(itemList: List[Item], @Suspended res: AsyncResponse) = {
-    println(itemList)
-
     val newItems = itemList.map(item => item.copy(id = Option(item.id).getOrElse(UUID.randomUUID.toString), createdAt = new Date()))
     items.insert(newItems).onComplete {
       case Success(_) => res.resume(Response.status(Status.CREATED).entity(Map("msg" -> "Created")).build())
-      case Failure(error) => {
-        error.printStackTrace();
-        res.resume(Response.status(Status.INTERNAL_SERVER_ERROR).entity(Map("msg" -> error.getMessage)).build())
-      }
+      case Failure(error) => res.resume(Response.status(Status.INTERNAL_SERVER_ERROR).entity(Map("msg" -> error.getMessage)).build())
     }
   }
 


### PR DESCRIPTION
Using UUID as primary is not only creating bigger indexes, but doesn't give us any meta info about the row itself. In Item table we are using first 13 characters from the SHA1 encoding of URL as id. With this we don't have to create extra indexes for filter by URL, additionally 13 size is half of 32 which is what UUID uses.

1. Item entries to take ID from client (optional)
2. Job primary key to be AutoInc BIGINT
3. Item primary key is (item.id, item.job_id)